### PR TITLE
Fix section alignment

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,7 +15,7 @@ OBJCOPY       := $(CROSS)objcopy
 
 # Flags - tune these to match your game's original compiler settings
 CFLAGS        := -Iinclude -O2 -mips1 -mfp32 -mno-abicalls -fno-pic -mno-shared \
-                 -G 0 -funsigned-char -fno-common \
+                 -G 4 -funsigned-char -fno-common \
                  -nostdinc -nostdlib -fno-builtin -fomit-frame-pointer \
                  -Wall
 

--- a/README.md
+++ b/README.md
@@ -39,4 +39,9 @@ Legend of Mana Decompilation Project
     ```bash
     make clean
     make
+    make bin
     ```
+
+## Notes Regarding Linkers
+At this time, I have not yet been able to get splat to produce a linker script that maps .sdata correctly. I'm still working on it. 
+Therefore, I've added `config/slus_010.13.ld` which is a custom linker that can be used to compile a byte-for-byte matching ELF.

--- a/config/SLUS_010.13.yaml
+++ b/config/SLUS_010.13.yaml
@@ -50,7 +50,7 @@ segments:
     type: code
     start: 0x800
     vram: 0x80010000
-    bss_size: 0x11050
+    bss_size: 0x10fe8
     subsegments:
       # Rodata and text together in one C file (like the original compilation)
       - [0x800, c, main]
@@ -60,9 +60,9 @@ segments:
 
       # .sdata (small initialized, GP-relative)
       - [0x2f414, sdata, gp_data]
-      - [0x2f420]
+      - [0x2f420]  # End of file data
       
-      # BSS
+      # BSS sections (uninitialized, not in file)
       - { vram: 0x8003EC20, type: sbss, name: sbss }
       - { vram: 0x8003EC88, type: bss, name: bss }
   

--- a/config/SLUS_010.13.yaml
+++ b/config/SLUS_010.13.yaml
@@ -56,7 +56,7 @@ segments:
       - [0x800, c, main]
 
       # .data (initialized)
-      - [0x25998, data, initialized]
+      - [0x25990, data, initialized]
 
       # .sdata (small initialized, GP-relative)
       - [0x2f414, sdata, gp_data]

--- a/config/slus_010.13.ld
+++ b/config/slus_010.13.ld
@@ -1,0 +1,101 @@
+/* Linker script for SLUS_010.13 PSX game */
+SECTIONS
+{
+    /* General ROM position */
+    __romPos = 0;
+
+    /* GP pointer for small data */
+    _gp = 0x8003EC14;
+
+    /* ------------------ HEADER ------------------ */
+    header_ROM_START = __romPos;
+    header_VRAM = ADDR(.header);
+
+    .header : AT(header_ROM_START) SUBALIGN(2)
+    {
+        FILL(0x00000000);
+        header_DATA_START = .;
+        build/asm/header.o(.data);
+        header_DATA_END = .;
+        header_DATA_SIZE = ABSOLUTE(header_DATA_END - header_DATA_START);
+    }
+
+    __romPos += SIZEOF(.header);
+    header_ROM_END = __romPos;
+    header_VRAM_END = .;
+
+    /* ------------------ MAIN SECTION ------------------ */
+    main_ROM_START = __romPos;
+    main_VRAM = 0x80010000;
+
+    .main main_VRAM : AT(main_ROM_START) SUBALIGN(2)
+    {
+        FILL(0x00000000);
+
+        /* Constructor/initialization table */
+        D_80010000 = .;
+        PROVIDE(D_80010000 = .);
+
+        /* RODATA */
+        main_RODATA_START = .;
+        build/src/main.o(.rodata);
+        . = ALIGN(., 16);
+        main_RODATA_END = .;
+        main_RODATA_SIZE = ABSOLUTE(main_RODATA_END - main_RODATA_START);
+
+        /* TEXT */
+        main_TEXT_START = .;
+        build/src/main.o(.text);
+        . = ALIGN(., 16);
+        main_TEXT_END = .;
+        main_TEXT_SIZE = ABSOLUTE(main_TEXT_END - main_TEXT_START);
+
+        /* DATA */
+        main_DATA_START = .;
+        build/src/main.o(.data);
+        build/asm/data/initialized.data.o(.data);
+        main_DATA_END = .;
+        main_DATA_SIZE = ABSOLUTE(main_DATA_END - main_DATA_START);
+    }
+
+    __romPos += SIZEOF(.main);
+    main_ROM_END = __romPos;
+    main_VRAM_END = .;
+
+    /* ------------------ SMALL DATA (.sdata) ------------------ */
+    .sdata 0x8003EC14 : AT(__romPos) SUBALIGN(2)
+    {
+        main_SDATA_START = .;
+        build/asm/data/gp_data.sdata.o(.sdata);
+        main_SDATA_END = .;
+        main_SDATA_SIZE = ABSOLUTE(main_SDATA_END - main_SDATA_START);
+    }
+
+    __romPos += SIZEOF(.sdata);
+
+    /* ------------------ SBSS (Small Uninitialized Data) ------------------ */
+    .sbss 0x8003EC20 (NOLOAD) : SUBALIGN(2)
+    {
+        main_SBSS_START = .;
+        build/asm/data/sbss.sbss.o(.sbss);
+        main_SBSS_END = .;
+        main_SBSS_SIZE = ABSOLUTE(main_SBSS_END - main_SBSS_START);
+    }
+
+    /* ------------------ BSS (Uninitialized Data) ------------------ */
+    .bss 0x8003EC88 (NOLOAD) : SUBALIGN(2)
+    {
+        main_BSS_START = .;
+        build/src/main.o(.bss);
+        build/asm/data/bss.bss.o(.bss);
+        . = ALIGN(., 16);
+        main_BSS_END = .;
+        main_BSS_SIZE = ABSOLUTE(main_BSS_END - main_BSS_START);
+    }
+
+    /* ------------------ DISCARD ALL OTHER ------------------ */
+    /DISCARD/ :
+    {
+        *(*);
+    }
+}


### PR DESCRIPTION
This adds some changes so that the build process produces a byte-for-byte binary file that matches the original code.
Note that I have not yet gotten splat to produce the right linker yet, so I added a custom one that can be used.