### PR TITLE
Decompile CD_SetAudioVolume

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Stage 1: grab compiler artifacts
-FROM old-gcc/gcc-2.7.2-psx AS toolchain
+FROM old-gcc/gcc-2.8.0-psx AS toolchain
 
 # Use Ubuntu LTS for stability and wide package availability
 FROM ubuntu:22.04

--- a/Makefile
+++ b/Makefile
@@ -79,10 +79,9 @@ COPY_SENTINEL := $(WORK_DIR)/.sources_copied
 # ---------------- Rules ----------------
 
 all: $(TARGET)
-	@echo "Copying $(TARGET) to $(FINAL_TARGET)..."
+	@echo "Copying build artifacts from $(WORK_DIR)/build/ to build/..."
 	@mkdir -p build
-	@cp $(TARGET) $(FINAL_TARGET)
-	@cp $(MAPFILE) $(FINAL_MAPFILE)
+	@cp -r $(WORK_DIR)/build/* build/
 	@echo "Build complete: $(FINAL_TARGET)"
 
 # Copy all source files to /tmp_build mirroring exact directory structure

--- a/README.md
+++ b/README.md
@@ -28,10 +28,10 @@ Copy your `SLUS_010.13` file into the `disc` folder in the project directory.
 
 ### 3. Build the Compiler Container
 
-The project uses an old PlayStation compiler (gcc-2.7.2) that runs in Docker. Build it with:
+The project uses an old PlayStation compiler (gcc-2.8.0) that runs in Docker. Build it with:
 
 ```bash
-docker build -t old-gcc/gcc-2.7.2-psx -f tools/old-gcc/gcc-2.7.2-psx.Dockerfile tools/old-gcc
+docker build -t old-gcc/gcc-2.8.0-psx -f tools/old-gcc/gcc-2.8.0-psx.Dockerfile tools/old-gcc
 ```
 
 This step may take several minutes.

--- a/config/symbol_addrs.txt
+++ b/config/symbol_addrs.txt
@@ -1,0 +1,2 @@
+CD_SetAudioVolume = 0x80013fd0;
+CdMix = 0x8001e894;

--- a/include/common.h
+++ b/include/common.h
@@ -3,5 +3,14 @@
 
 #include "include_asm.h"
 
+typedef unsigned char	u_char;
+typedef struct {
+	u_char	val0;		/* volume for CD(L) -> SPU (L) */
+	u_char	val1;		/* volume for CD(L) -> SPU (R) */
+	u_char	val2;		/* volume for CD(R) -> SPU (L) */
+	u_char	val3;		/* volume for CD(R) -> SPU (R) */
+} CdlATV;	
+
+int CdMix(CdlATV *vol);
 
 #endif

--- a/src/main.c
+++ b/src/main.c
@@ -26,7 +26,35 @@ INCLUDE_ASM("asm/nonmatchings/main", func_80013F2C);
 
 INCLUDE_ASM("asm/nonmatchings/main", func_80013F64);
 
-INCLUDE_ASM("asm/nonmatchings/main", func_80013FD0);
+/*
+ * Set audio volume for a specific stereo channel
+ *
+ * Params:
+ *   volume - Volume level to set (0-255)
+ *   stereoChannel - 0 for left channel, non-zero for right channel
+ *
+ * Returns: void
+ * 
+ * decomp.me link: https://decomp.me/scratch/XbegS
+ * decomp.me (%): 99.12%
+ */
+void CD_SetAudioVolume(u_char volume, int stereoChannel)
+{
+    CdlATV audioConfig[2];
+    
+    if (stereoChannel != 0) {
+        audioConfig[0].val0 = volume;
+        audioConfig[0].val1 = 0;
+        audioConfig[0].val2 = volume;
+    } else {
+        audioConfig[0].val0 = volume;
+        audioConfig[0].val1 = volume;
+        audioConfig[0].val2 = 0;
+        audioConfig[0].val3 = 0;
+    }
+    
+    CdMix(audioConfig);
+}
 
 INCLUDE_ASM("asm/nonmatchings/main", func_80014014);
 
@@ -314,7 +342,7 @@ INCLUDE_ASM("asm/nonmatchings/main", func_8001E614);
 
 INCLUDE_ASM("asm/nonmatchings/main", func_8001E748);
 
-INCLUDE_ASM("asm/nonmatchings/main", func_8001E894);
+INCLUDE_ASM("asm/nonmatchings/main", CdMix);
 
 INCLUDE_ASM("asm/nonmatchings/main", func_8001E8B4);
 


### PR DESCRIPTION
- Adds decompilation and symbols for CD_SetAudioVolume.
- Updates gcc to 2.8.0 due to branch delay slot usage for matching.